### PR TITLE
Local remake of #2: respect of custom admin options for changelist, django >=1.6

### DIFF
--- a/django_tablib/admin/__init__.py
+++ b/django_tablib/admin/__init__.py
@@ -81,14 +81,20 @@ class TablibAdmin(admin.ModelAdmin):
         # allow other admin clases to override change list view,
         # taken from django ModelAdmin
         ChangeList = self.get_changelist(request)
+
+        list_display = self.get_list_display(request)
+        list_display_links = self.get_list_display_links(request, list_display)
+        list_filter = self.get_list_filter(request)
+        search_fields = self.get_search_fields(request)
+
         cl = ChangeList(
             request,
             self.model,
-            self.list_display,
-            self.list_display_links,
-            self.list_filter,
+            list_display,
+            list_display_links,
+            list_filter,
             self.date_hierarchy,
-            self.search_fields,
+            search_fields,
             self.list_select_related,
             self.list_per_page,
             self.list_max_show_all,

--- a/django_tablib/admin/__init__.py
+++ b/django_tablib/admin/__init__.py
@@ -85,7 +85,9 @@ class TablibAdmin(admin.ModelAdmin):
         list_display = self.get_list_display(request)
         list_display_links = self.get_list_display_links(request, list_display)
         list_filter = self.get_list_filter(request)
-        search_fields = self.get_search_fields(request)
+        search_fields = (self.get_search_fields(request)
+                         if hasattr(self, 'get_search_fields')
+                         else self.search_fields)
 
         cl = ChangeList(
             request,


### PR DESCRIPTION
master has been merged to clean up commits.

`ChangeList` `get_queryset` should respect custom options, remake of `django-tablib` PR #38
Covers both `Django 1.6` and greater.
