### PR TITLE
Remake defer character encoding clean version

### DIFF
--- a/django_tablib/admin/__init__.py
+++ b/django_tablib/admin/__init__.py
@@ -33,6 +33,7 @@ class TablibAdmin(admin.ModelAdmin):
     # enable Export to _format_ admin actions by default, this allows to export
     # only selected items.
     enable_admin_actions = True
+    export_encoding = 'utf-8'
 
     def __init__(self, *args, **kwargs):
         for export_format in self.formats:
@@ -76,7 +77,7 @@ class TablibAdmin(admin.ModelAdmin):
         filename = datetime.datetime.now().strftime(self.export_filename)
         return export(request, queryset=queryset, model=self.model,
                       headers=self.headers, file_type=export_format,
-                      filename=filename)
+                      filename=filename, encoding=self.export_encoding)
 
     def get_tablib_queryset(self, request):
         # allow other admin clases to override change list view,

--- a/django_tablib/admin/actions.py
+++ b/django_tablib/admin/actions.py
@@ -7,7 +7,7 @@ from django.utils.encoding import smart_str
 from django.utils.translation import ugettext_lazy as _
 
 from django_tablib.datasets import SimpleDataset
-from django_tablib.base import mimetype_map
+from django_tablib.base import get_content_type
 
 
 def tablib_export_action(modeladmin, request, queryset, file_type="xls"):
@@ -23,10 +23,9 @@ def tablib_export_action(modeladmin, request, queryset, file_type="xls"):
     filename = '{0}.{1}'.format(
         smart_str(modeladmin.model._meta.verbose_name_plural), file_type)
 
-    response_kwargs = {}
-    key = 'content_type' if get_version().split('.')[1] > 6 else 'mimetype'
-    response_kwargs[key] = mimetype_map.get(
-        file_type, 'application/octet-stream')
+    response_kwargs = {
+        'content_type': get_content_type(file_type)
+    }
 
     response = HttpResponse(getattr(dataset, file_type), **response_kwargs)
     response['Content-Disposition'] = 'attachment; filename={0}'.format(

--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -16,8 +16,6 @@ mimetype_map = {
 
 class BaseDataset(tablib.Dataset):
 
-    encoding = 'utf-8'
-
     def __init__(self):
         data = map(self._getattrs, self.queryset)
         super(BaseDataset, self).__init__(headers=self.header_list, *data)
@@ -25,19 +23,15 @@ class BaseDataset(tablib.Dataset):
     def _cleanval(self, value, attr):
         if callable(value):
             value = value()
-        elif value is None or unicode(value) == u"None":
+        elif value is None or tablib.compat.unicode(value) == u"None":
             value = ""
 
-        t = type(value)
-        if t is str:
-            return value
-        elif t is bool:
+        if isinstance(value, bool):
             value = _("Y") if value else _("N")
-            return smart_unicode(value).encode(self.encoding)
-        elif t in [datetime.date, datetime.datetime]:
-            return date(value, 'SHORT_DATE_FORMAT').encode(self.encoding)
+        elif isinstance(value, (datetime.date, datetime.datetime)):
+            value = date(value, 'SHORT_DATE_FORMAT')
 
-        return smart_unicode(value).encode(self.encoding)
+        return smart_unicode(value)
 
     def _getattrs(self, obj):
         attrs = []

--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -17,6 +17,15 @@ mimetype_map = {
 }
 
 
+def get_content_type(export_format, encoding='utf-8'):
+    """
+    Simple wrapper to ensure that content type is set with respect to encoding
+    """
+    return '{0}; charset={1}'.format(
+        mimetype_map.get(export_format, 'application/octet-stream'),
+        encoding)
+
+
 class BaseDataset(tablib.Dataset):
 
     def __init__(self):
@@ -26,7 +35,7 @@ class BaseDataset(tablib.Dataset):
     def _cleanval(self, value, attr):
         if callable(value):
             value = value()
-        elif value is None or tablib.compat.unicode(value) == u"None":
+        elif value is None or tablib.compat.unicode(value) == "None":
             value = ""
 
         if isinstance(value, bool):

--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -2,7 +2,7 @@ import datetime
 import tablib
 
 from django.template.defaultfilters import date
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 mimetype_map = {
@@ -31,7 +31,7 @@ class BaseDataset(tablib.Dataset):
         elif isinstance(value, (datetime.date, datetime.datetime)):
             value = date(value, 'SHORT_DATE_FORMAT')
 
-        return smart_unicode(value)
+        return force_text(value)
 
     def _getattrs(self, obj):
         attrs = []

--- a/django_tablib/views.py
+++ b/django_tablib/views.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured

--- a/django_tablib/views.py
+++ b/django_tablib/views.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, absolute_import
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -10,12 +11,12 @@ try:
 except ImportError:
     from django.db.models.loading import get_model
 
-from .base import mimetype_map
+from .base import get_content_type
 from .datasets import SimpleDataset
 
 
 def export(request, queryset=None, model=None, headers=None, file_type='xls',
-           filename='export'):
+           filename='export', encoding='utf-8'):
     if queryset is None:
         queryset = model.objects.all()
 
@@ -24,10 +25,9 @@ def export(request, queryset=None, model=None, headers=None, file_type='xls',
     if not hasattr(dataset, file_type):
         raise Http404
 
-    response_kwargs = {}
-    key = 'content_type'
-    response_kwargs[key] = mimetype_map.get(
-        file_type, 'application/octet-stream')
+    response_kwargs = {
+        'content_type': get_content_type(file_type, encoding=encoding)
+    }
 
     response = HttpResponse(getattr(dataset, file_type), **response_kwargs)
 


### PR DESCRIPTION
PR #4 but way more cleaner, only needed commits in the diff.
- Solves `django-tabilib` issue with unicode characters
- Add a default `utf-8` encoding to response header (content-type)
- minor code style improvements.
